### PR TITLE
[billing] adds options to projects list

### DIFF
--- a/acceptance/masterdata/billing/projects_test.go
+++ b/acceptance/masterdata/billing/projects_test.go
@@ -55,7 +55,7 @@ func TestProjectList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Get projects
-	allPages, err := projects.List(client).AllPages()
+	allPages, err := projects.List(client, projects.ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
 
 	allProjects, err := projects.ExtractProjects(allPages)

--- a/billing/masterdata/domains/requests.go
+++ b/billing/masterdata/domains/requests.go
@@ -27,7 +27,7 @@ type ListOptsBuilder interface {
 	ToDomainListQuery() (string, error)
 }
 
-// ListOpts is a structure that holds options for listing project masterdata.
+// ListOpts is a structure that holds options for listing domain masterdata.
 type ListOpts struct {
 	CheckCOValidity bool      `q:"checkCOValidity"`
 	ExcludeDeleted  bool      `q:"excludeDeleted"`

--- a/billing/masterdata/projects/requests.go
+++ b/billing/masterdata/projects/requests.go
@@ -23,6 +23,12 @@ import (
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToProjectListQuery() (string, error)
+}
+
 // ListOpts is a structure that holds options for listing project masterdata.
 type ListOpts struct {
 	CheckCOValidity bool      `q:"checkCOValidity"`
@@ -48,14 +54,8 @@ func (opts ListOpts) ToProjectListQuery() (string, error) {
 }
 
 // List returns a Pager which allows you to iterate over a collection of
-// projects.
-func List(c *gophercloud.ServiceClient) pagination.Pager {
-	return ListWithOpts(c, ListOpts{})
-}
-
-// List returns a Pager which allows you to iterate over a collection of
-// projects optionally filtered by ListOpts
-func ListWithOpts(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+// projects
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	serviceURL := listURL(c)
 	if opts != (ListOpts{}) {
 		query, err := opts.ToProjectListQuery()

--- a/billing/masterdata/projects/requests.go
+++ b/billing/masterdata/projects/requests.go
@@ -16,15 +16,55 @@ package projects
 
 import (
 	"encoding/json"
+	"net/url"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
+// ListOpts is a structure that holds options for listing project masterdata.
+type ListOpts struct {
+	CheckCOValidity bool      `q:"checkCOValidity"`
+	ExcludeDeleted  bool      `q:"excludeDeleted"`
+	From            time.Time `q:"-"`
+}
+
+// ToProjectListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToProjectListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	params := q.Query()
+
+	if opts.From != (time.Time{}) {
+		params.Add("from", opts.From.Format(gophercloud.RFC3339MilliNoZ))
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+
+	return q.String(), nil
+}
+
 // List returns a Pager which allows you to iterate over a collection of
 // projects.
 func List(c *gophercloud.ServiceClient) pagination.Pager {
-	return pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
+	return ListWithOpts(c, ListOpts{})
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// projects optionally filtered by ListOpts
+func ListWithOpts(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	serviceURL := listURL(c)
+	if opts != (ListOpts{}) {
+		query, err := opts.ToProjectListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		serviceURL += query
+	}
+	return pagination.NewPager(c, serviceURL, func(r pagination.PageResult) pagination.Page {
 		return ProjectPage{pagination.SinglePageBase(r)}
 	})
 }

--- a/billing/masterdata/projects/testing/requests_test.go
+++ b/billing/masterdata/projects/testing/requests_test.go
@@ -117,6 +117,39 @@ func TestList(t *testing.T) {
 	th.CheckDeepEquals(t, projectsList, actual)
 }
 
+func TestListOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/masterdata/projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		th.CheckEquals(t, r.URL.Query().Get("checkCOValidity"), "true")
+		th.CheckEquals(t, r.URL.Query().Get("excludeDeleted"), "true")
+		th.CheckEquals(t, r.URL.Query().Get("from"), "2023-04-26T12:31:42.1337")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, ListResponse)
+	})
+
+	listOpts := projects.ListOpts{
+		CheckCOValidity: true,
+		ExcludeDeleted:  true,
+		From:            time.Date(2023, 04, 26, 12, 31, 42, 133700000, time.UTC),
+	}
+
+	allProjects, err := projects.ListWithOpts(fake.ServiceClient(), listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	actual, err := projects.ExtractProjects(allProjects)
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, projectsList, actual)
+}
+
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/billing/masterdata/projects/testing/requests_test.go
+++ b/billing/masterdata/projects/testing/requests_test.go
@@ -108,7 +108,7 @@ func TestList(t *testing.T) {
 		fmt.Fprint(w, ListResponse)
 	})
 
-	allProjects, err := projects.List(fake.ServiceClient()).AllPages()
+	allProjects, err := projects.List(fake.ServiceClient(), projects.ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
 
 	actual, err := projects.ExtractProjects(allProjects)
@@ -141,7 +141,7 @@ func TestListOpts(t *testing.T) {
 		From:            time.Date(2023, 04, 26, 12, 31, 42, 133700000, time.UTC),
 	}
 
-	allProjects, err := projects.ListWithOpts(fake.ServiceClient(), listOpts).AllPages()
+	allProjects, err := projects.List(fake.ServiceClient(), listOpts).AllPages()
 	th.AssertNoErr(t, err)
 
 	actual, err := projects.ExtractProjects(allProjects)


### PR DESCRIPTION
The Billing API supports query parameters for the list endpoint, but this library does not.
The documentation of the Billing API describes these query options: `checkCOValidity`, `excludeDeleted` and `from`. The former two are boolean flags while the third limits the result to projects that have been changed after this timestamp. 

The service I am using the Billing API in syncs the ProjectMetadata regularly. Since we have many projects within sapcc and the metadata is rather static, it is more efficient to only retrieve projects that have been changed since the last sync.

Other billing endpoints that support options have a List function such as https://github.com/sapcc/gophercloud-sapcc/blob/326e6b5e335136eece8e77e03998345bf0e84a81/billing/masterdata/price/requests.go#L58
Adding `ListOpts` to the existing `List` function will break existing implementations. Therefore an additional method that allows the passing of `ListOpts` has been added.