### PR TITLE
feat(issue47): add metis client and get/list projects

### DIFF
--- a/clients/clients.go
+++ b/clients/clients.go
@@ -126,3 +126,21 @@ func NewArcV1(client *gophercloud.ProviderClient, endpointOpts gophercloud.Endpo
 		ResourceBase:   resourceBase,
 	}, nil
 }
+
+// NewMetisV1 creates a ServiceClient that may be used with the v1 metis package.
+func NewMetisV1(client *gophercloud.ProviderClient, endpointOpts gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	sc := new(gophercloud.ServiceClient)
+	endpointOpts.ApplyDefaults("metis")
+	url, err := client.EndpointLocator(endpointOpts)
+	if err != nil {
+		return sc, err
+	}
+
+	resourceBase := url + "v1/"
+	return &gophercloud.ServiceClient{
+		ProviderClient: client,
+		Endpoint:       url,
+		Type:           "metis",
+		ResourceBase:   resourceBase,
+	}, nil
+}

--- a/metis/v1/identity/projects/model.go
+++ b/metis/v1/identity/projects/model.go
@@ -1,0 +1,66 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projects
+
+// Project represents a Keystone project.
+type Project struct {
+	Name          string        `json:"name,omitempty"`
+	UUID          string        `json:"uuid"`
+	Description   string        `json:"description,omitempty"`
+	DomainName    string        `json:"domainName,omitempty"`
+	DomainUUID    string        `json:"domainUUID,omitempty"`
+	CBRMasterdata CBRMasterdata `json:"cbrMasterdata,omitempty"`
+	Users         []User        `json:"users"`
+}
+
+// CBRMasterdata represents the CBR masterdata of a Keystone project.
+type CBRMasterdata struct {
+	CostObjectName                  string                 `json:"costObjectName,omitempty"`
+	CostObjectType                  string                 `json:"costObjectType,omitempty"`
+	CostObjectInherited             bool                   `json:"costObjectInherited,omitempty"`
+	BusinessCriticality             string                 `json:"businessCriticality,omitempty"`
+	RevenueRelevance                string                 `json:"revenueRelevance,omitempty"`
+	NumberOfEndusers                int                    `json:"numberOfEndusers,omitempty"`
+	PrimaryContactUserID            string                 `json:"primaryContactUserID,omitempty"`
+	PrimaryContactEmail             string                 `json:"primaryContactEmail,omitempty"`
+	OperatorUserID                  string                 `json:"operatorUserID,omitempty"`
+	OperatorEmail                   string                 `json:"operatorEmail,omitempty"`
+	InventoryRoleUserID             string                 `json:"inventoryRoleUserID,omitempty"`
+	InventoryRoleEmail              string                 `json:"inventoryRoleEmail,omitempty"`
+	InfrastructureCoordinatorUserID string                 `json:"infrastructureCoordinatorUserID,omitempty"`
+	InfrastructureCoordinatorEmail  string                 `json:"infrastructureCoordinatorEmail,omitempty"`
+	ExternalCertifications          ExternalCertifications `json:"externalCertifications,omitempty"`
+	GPUEnabled                      bool                   `json:"gpuEnabled,omitempty"`
+	ContainsPIIDPPHR                bool                   `json:"containsPIIDPPHR,omitempty"`
+	ContainsExternalCustomerData    bool                   `json:"containsExternalCustomerData,omitempty"`
+}
+
+// ExternalCertifications represents the external certifications of a Keystone project.
+type ExternalCertifications struct {
+	ISO  bool `json:"ISO,omitempty"`
+	PCI  bool `json:"PCI,omitempty"`
+	SOC1 bool `json:"SOC1,omitempty"`
+	SOC2 bool `json:"SOC2,omitempty"`
+	C5   bool `json:"C5,omitempty"`
+	SOX  bool `json:"SOX,omitempty"`
+}
+
+// User represents a Keystone user.
+type User struct {
+	UUID        string `json:"uuid"`
+	Name        string `json:"name,omitempty"`
+	Email       string `json:"email,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/metis/v1/identity/projects/requests.go
+++ b/metis/v1/identity/projects/requests.go
@@ -1,0 +1,65 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projects
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToProjectListQuery() (string, error)
+}
+
+// ListOpts is a structure that holds options for listing project masterdata.
+type ListOpts struct {
+	// Limit will limit the number of results returned.
+	Limit int `q:"limit"`
+	// UUIDs will only return projects with the specified UUIDs.
+	UUIDs []string `q:"uuids"`
+}
+
+// ToProjectListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToProjectListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// projects.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	serviceURL := listURL(client)
+	if opts != nil {
+		query, err := opts.ToProjectListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		serviceURL += query
+	}
+	return pagination.NewPager(client, serviceURL, v1.CreatePage())
+}
+
+// Get retrieves a specific project based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(getURL(c, id), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/metis/v1/identity/projects/results.go
+++ b/metis/v1/identity/projects/results.go
@@ -1,0 +1,89 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projects
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+)
+
+// ProjectPage
+type ProjectPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of projects contains any results.
+func (r ProjectPage) IsEmpty() (bool, error) {
+	projects, err := ExtractProjects(r)
+	if err != nil {
+		return true, err
+	}
+	return len(projects) == 0, nil
+}
+
+// NextPageURL extracts the "next" link from the response.
+func (r ProjectPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, err
+}
+
+// ExtractProjects accepts a Page struct, specifically an ProjectsPage struct,
+// and extracts the elements into a slice of Projects structs.
+func ExtractProjects(r pagination.Page) ([]Project, error) {
+	var s struct {
+		Projects []Project `json:"items"`
+	}
+	if err := (r.(v1.CommonPage)).ExtractInto(&s); err != nil {
+		return []Project{}, err
+	}
+	return s.Projects, nil
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as a Project.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a project
+// resource.
+func (r GetResult) Extract() (*Project, error) {
+	var s struct {
+		Data struct {
+			Items []Project `json:"items"`
+		} `json:"data"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	if s.Data.Items == nil {
+		return nil, nil
+	}
+	return &s.Data.Items[0], nil
+}
+
+func (r GetResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}

--- a/metis/v1/identity/projects/testing/fixtures.go
+++ b/metis/v1/identity/projects/testing/fixtures.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// HandleGetProjectSuccessfully creates an HTTP handler at `/identity/project/:project_id` on the
+// test handler mux that responds with a single project.
+func HandleGetProjectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/identity/project/project-1", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		jsonBytes, err := os.ReadFile(filepath.Join("fixtures", "get.json"))
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}
+
+// HandleGetProjectSuccessfully creates an HTTP handler at `/identity/project` on the
+// test handler mux that responds with a list of projects.
+func HandleListProjectsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/identity/project", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var jsonBytes []byte
+		var err error
+
+		switch r.URL.Query().Has("limit") && !r.URL.Query().Has("cursor") {
+		case true:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list_with_next.json"))
+			th.AssertNoErr(t, err)
+
+			var resp struct {
+				APIVersion string         `json:"apiVersion"`
+				Data       map[string]any `json:"data"`
+			}
+			err = json.Unmarshal(jsonBytes, &resp)
+			th.AssertNoErr(t, err)
+			// adding a nextLink to the pagination response
+			resp.Data["nextLink"] = th.Endpoint() + "/identity/project?cursor=dummycursor&limit=1"
+			jsonBytes, err = json.Marshal(resp)
+		default:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list.json"))
+		}
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}

--- a/metis/v1/identity/projects/testing/fixtures/get.json
+++ b/metis/v1/identity/projects/testing/fixtures/get.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "project",
+    "region": "germany",
+    "items": [
+      {
+        "name": "project1",
+        "uuid": "project-1",
+        "description": "project1 descr",
+        "domainName": "domain1",
+        "domainUUID": "domain-1",
+        "cbrMasterdata": {
+          "costObjectName": "my-cost-object",
+          "costObjectType": "IO",
+          "costObjectInherited": true,
+          "businessCriticality": "test",
+          "revenueRelevance": "true",
+          "numberOfEndusers": 0,
+          "primaryContactUserID": "i001337",
+          "primaryContactEmail": "max.mustermann@sample.com",
+          "operatorUserID": "i001337",
+          "operatorEmail": "max.mustermann@sample.com",
+          "inventoryRoleUserID": "i001337",
+          "inventoryRoleEmail": "max.mustermann@sample.com",
+          "infrastructureCoordinatorUserID": "i001337",
+          "infrastructureCoordinatorEmail": "max.mustermann@sample.com",
+          "externalCertifications": {
+            "ISO": false,
+            "PCI": true,
+            "SOC1": false,
+            "SOC2": false,
+            "C5": false,
+            "SOX": false
+          },
+          "gpuEnabled": false,
+          "containsPIIDPPHR": true,
+          "containsExternalCustomerData": true
+        },
+        "users": [
+          {
+            "uuid": "1234abcd",
+            "name": "Max Mustermann",
+            "email": "max.mustermann@sample.com",
+            "description": "muster"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/metis/v1/identity/projects/testing/fixtures/list.json
+++ b/metis/v1/identity/projects/testing/fixtures/list.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "project",
+    "region": "qa-de-1",
+    "items": [ 
+      {
+        "name": "project2",
+        "uuid": "project-2",
+        "description": "project2 descr",
+        "domainName": "domain2",
+        "domainUUID": "domain-2",
+        "cbrMasterdata": {
+          "costObjectName": "my-cost-object",
+          "costObjectType": "IO",
+          "costObjectInherited": false,
+          "businessCriticality": "test",
+          "revenueRelevance": "true",
+          "numberOfEndusers": 0,
+          "primaryContactUserID": "i001337",
+          "primaryContactEmail": "max.mustermann@sample.com",
+          "operatorUserID": "i001337",
+          "operatorEmail": "max.mustermann@sample.com",
+          "inventoryRoleUserID": "i001337",
+          "inventoryRoleEmail": "max.mustermann@sample.com",
+          "infrastructureCoordinatorUserID": "i001337",
+          "infrastructureCoordinatorEmail": "max.mustermann@sample.com",
+          "externalCertifications": {
+            "ISO": false,
+            "PCI": false,
+            "SOC1": false,
+            "SOC2": false,
+            "C5": false,
+            "SOX": false
+          },
+          "gpuEnabled": false,
+          "containsPIIDPPHR": true,
+          "containsExternalCustomerData": true
+        },
+        "users": [
+          {
+            "uuid": "abcd1234",
+            "name": "TU1234"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/metis/v1/identity/projects/testing/fixtures/list_with_next.json
+++ b/metis/v1/identity/projects/testing/fixtures/list_with_next.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "project",
+    "region": "qa-de-1",
+    "items": [{
+        "name": "project1",
+        "uuid": "project-1",
+        "description": "project1 descr",
+        "domainName": "domain1",
+        "domainUUID": "domain-1",
+        "cbrMasterdata": {
+          "costObjectName": "my-cost-object",
+          "costObjectType": "IO",
+          "costObjectInherited": true,
+          "businessCriticality": "test",
+          "revenueRelevance": "true",
+          "numberOfEndusers": 0,
+          "primaryContactUserID": "i001337",
+          "primaryContactEmail": "max.mustermann@sample.com",
+          "operatorUserID": "i001337",
+          "operatorEmail": "max.mustermann@sample.com",
+          "inventoryRoleUserID": "i001337",
+          "inventoryRoleEmail": "max.mustermann@sample.com",
+          "infrastructureCoordinatorUserID": "i001337",
+          "infrastructureCoordinatorEmail": "max.mustermann@sample.com",
+          "externalCertifications": {
+            "ISO": false,
+            "PCI": true,
+            "SOC1": false,
+            "SOC2": false,
+            "C5": false,
+            "SOX": false
+          },
+          "gpuEnabled": false,
+          "containsPIIDPPHR": true,
+          "containsExternalCustomerData": true
+        },
+        "users": [
+          {
+            "uuid": "1234abcd",
+            "name": "Max Mustermann",
+            "email": "max.mustermann@sample.com",
+            "description": "muster"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/metis/v1/identity/projects/testing/requests_test.go
+++ b/metis/v1/identity/projects/testing/requests_test.go
@@ -1,0 +1,179 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
+
+	"github.com/sapcc/gophercloud-sapcc/metis/v1/identity/projects"
+)
+
+func TestGetProject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetProjectSuccessfully(t)
+
+	actual, err := projects.Get(fakeclient.ServiceClient(), "project-1").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &projects.Project{
+		Name:        "project1",
+		UUID:        "project-1",
+		Description: "project1 descr",
+		DomainName:  "domain1",
+		DomainUUID:  "domain-1",
+		CBRMasterdata: projects.CBRMasterdata{
+			CostObjectName:                  "my-cost-object",
+			CostObjectType:                  "IO",
+			CostObjectInherited:             true,
+			BusinessCriticality:             "test",
+			RevenueRelevance:                "true",
+			NumberOfEndusers:                0,
+			PrimaryContactUserID:            "i001337",
+			PrimaryContactEmail:             "max.mustermann@sample.com",
+			OperatorUserID:                  "i001337",
+			OperatorEmail:                   "max.mustermann@sample.com",
+			InventoryRoleUserID:             "i001337",
+			InventoryRoleEmail:              "max.mustermann@sample.com",
+			InfrastructureCoordinatorUserID: "i001337",
+			InfrastructureCoordinatorEmail:  "max.mustermann@sample.com",
+			ExternalCertifications: projects.ExternalCertifications{
+				ISO:  false,
+				PCI:  true,
+				SOC1: false,
+				SOC2: false,
+				C5:   false,
+				SOX:  false,
+			},
+			GPUEnabled:                   false,
+			ContainsPIIDPPHR:             true,
+			ContainsExternalCustomerData: true,
+		},
+		Users: []projects.User{
+			{
+				UUID:        "1234abcd",
+				Name:        "Max Mustermann",
+				Email:       "max.mustermann@sample.com",
+				Description: "muster",
+			},
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestListProjects(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListProjectsSuccessfully(t)
+	opts := projects.ListOpts{
+		Limit: 1,
+	}
+
+	p, err := projects.List(fakeclient.ServiceClient(), opts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := projects.ExtractProjects(p)
+	th.AssertNoErr(t, err)
+
+	expected := []projects.Project{
+		{
+			Name:        "project1",
+			UUID:        "project-1",
+			Description: "project1 descr",
+			DomainName:  "domain1",
+			DomainUUID:  "domain-1",
+			CBRMasterdata: projects.CBRMasterdata{
+				CostObjectName:                  "my-cost-object",
+				CostObjectType:                  "IO",
+				CostObjectInherited:             true,
+				BusinessCriticality:             "test",
+				RevenueRelevance:                "true",
+				NumberOfEndusers:                0,
+				PrimaryContactUserID:            "i001337",
+				PrimaryContactEmail:             "max.mustermann@sample.com",
+				OperatorUserID:                  "i001337",
+				OperatorEmail:                   "max.mustermann@sample.com",
+				InventoryRoleUserID:             "i001337",
+				InventoryRoleEmail:              "max.mustermann@sample.com",
+				InfrastructureCoordinatorUserID: "i001337",
+				InfrastructureCoordinatorEmail:  "max.mustermann@sample.com",
+				ExternalCertifications: projects.ExternalCertifications{
+					ISO:  false,
+					PCI:  true,
+					SOC1: false,
+					SOC2: false,
+					C5:   false,
+					SOX:  false,
+				},
+				GPUEnabled:                   false,
+				ContainsPIIDPPHR:             true,
+				ContainsExternalCustomerData: true,
+			},
+			Users: []projects.User{
+				{
+					UUID:        "1234abcd",
+					Name:        "Max Mustermann",
+					Email:       "max.mustermann@sample.com",
+					Description: "muster",
+				},
+			},
+		},
+		{
+			Name:        "project2",
+			UUID:        "project-2",
+			Description: "project2 descr",
+			DomainName:  "domain2",
+			DomainUUID:  "domain-2",
+			CBRMasterdata: projects.CBRMasterdata{
+				CostObjectName:                  "my-cost-object",
+				CostObjectType:                  "IO",
+				CostObjectInherited:             false,
+				BusinessCriticality:             "test",
+				RevenueRelevance:                "true",
+				NumberOfEndusers:                0,
+				PrimaryContactUserID:            "i001337",
+				PrimaryContactEmail:             "max.mustermann@sample.com",
+				OperatorUserID:                  "i001337",
+				OperatorEmail:                   "max.mustermann@sample.com",
+				InventoryRoleUserID:             "i001337",
+				InventoryRoleEmail:              "max.mustermann@sample.com",
+				InfrastructureCoordinatorUserID: "i001337",
+				InfrastructureCoordinatorEmail:  "max.mustermann@sample.com",
+				ExternalCertifications: projects.ExternalCertifications{
+					ISO:  false,
+					PCI:  false,
+					SOC1: false,
+					SOC2: false,
+					C5:   false,
+					SOX:  false,
+				},
+				GPUEnabled:                   false,
+				ContainsPIIDPPHR:             true,
+				ContainsExternalCustomerData: true,
+			},
+			Users: []projects.User{
+				{
+					UUID: "abcd1234",
+					Name: "TU1234",
+				},
+			},
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/metis/v1/identity/projects/urls.go
+++ b/metis/v1/identity/projects/urls.go
@@ -1,0 +1,25 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projects
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("identity", "project")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("identity", "project", id)
+}

--- a/metis/v1/pagination.go
+++ b/metis/v1/pagination.go
@@ -1,0 +1,78 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/gophercloud/gophercloud/pagination"
+
+// CommonPage is the common base type for all pagination pages used by Metis V1 endpoints.
+type CommonPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty determines whether or not a page of projects contains any results.
+func (p CommonPage) IsEmpty() (bool, error) {
+	items, err := extractItems(p)
+	if err != nil {
+		return true, err
+	}
+	return len(items) == 0, nil
+}
+
+// NextPageURL extracts the "next" link from the response.
+func (p CommonPage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+
+	err := p.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Next, err
+}
+
+func extractItems(p pagination.Page) ([]any, error) {
+	var s struct {
+		Items []any `json:"items"`
+	}
+	if err := (p.(CommonPage)).ExtractInto(&s); err != nil {
+		return []any{}, err
+	}
+	return s.Items, nil
+}
+
+// CreatePage is used to use pagination.NewPager with any of the Metis V1 endpoints.
+func CreatePage() func(pagination.PageResult) pagination.Page {
+	return func(r pagination.PageResult) pagination.Page {
+		// The structure of the Metis API response has the list of projects not on the top level, but nested in the "data" field.
+		// pagination.Pager does not work with this structure, so we extract the list of projects and the next page URL.
+		// The body is then replaced with a map containing the list of projects and the next page URL, which is then
+		// compatible with the pagination.
+		var source struct {
+			Data struct {
+				Items []any  `json:"items"`
+				Next  string `json:"nextLink"`
+			} `json:"data"`
+		}
+		if err := r.ExtractInto(&source); err != nil {
+			return nil
+		}
+		newBody := make(map[string]any, 2)
+		newBody["items"] = source.Data.Items
+		newBody["next"] = source.Data.Next
+		r.Body = newBody
+		return CommonPage{pagination.LinkedPageBase{PageResult: r}}
+	}
+}


### PR DESCRIPTION
This PR adds a client for the internally available API of Metis and an implementation for the `/v1/identity/projects` endpoint.
Pagination did not work out of the box because the API result is structured like such:
```json
{
  "apiVersion": "1.0",
  "data": {
    "kind": "project",
    "region": "germany",
    "items": [
      {
       #project content
      }
    ]
  }
}
```
The pagination.Pager expects that the slice containing the results isn't nested within the JSON.
To still be able to use the existing pagination I have added removed the nesting in `createPage(..)` like this: https://github.com/sapcc/gophercloud-sapcc/compare/feat/issue47/projects?expand=1#diff-88c233df57ce1dba903770d06b822a3045788c3034473ddafe714f16649a6a4bR54-R71