### PR TITLE
feat(metis): add ip&dns endpoint handler

### DIFF
--- a/metis/v1/identity/costobjects/requests.go
+++ b/metis/v1/identity/costobjects/requests.go
@@ -33,7 +33,7 @@ type ListOpts struct {
 	Project string `q:"project"`
 	// Domain will only return costobjects for the specified domain uuid.
 	Domain string `q:"domain"`
-	// Limit will limit the number of results returned.
+	// Limit will limit the number of results returned per page.
 	Limit int `q:"limit"`
 	// UUIDs will only return costobjects with the specified UUIDs.
 	UUIDs []string `q:"uuids"`

--- a/metis/v1/identity/projects/requests.go
+++ b/metis/v1/identity/projects/requests.go
@@ -29,7 +29,7 @@ type ListOptsBuilder interface {
 
 // ListOpts is a structure that holds options for listing project masterdata.
 type ListOpts struct {
-	// Limit will limit the number of results returned.
+	// Limit will limit the number of results returned per page.
 	Limit int `q:"limit"`
 	// UUIDs will only return projects with the specified UUIDs.
 	UUIDs []string `q:"uuids"`

--- a/metis/v1/network/dns/requests.go
+++ b/metis/v1/network/dns/requests.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domains
+package dns
 
 import (
 	"github.com/gophercloud/gophercloud"
@@ -24,29 +24,34 @@ import (
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {
-	ToDomainListQuery() (string, error)
+	ToZoneListQuery() (string, error)
 }
 
-// ListOpts is a structure that holds options for listing domain masterdata.
+// ListOpts is a structure that holds options for listing DNS zones.
 type ListOpts struct {
+	// Name is the DNS Zone name and may include *-wildcards.
+	Name string `q:"name"`
+	// UUIDs will only return DNS Zones with the specified UUIDs.
+	UUIDs []string `q:"uuids"`
+	// DomainID will only return DNS Zones with the specified DomainID.
+	DomainID string `q:"domain"`
+	// ProjectID will only return DNS Zones with the specified ProjectID.
+	ProjectID string `q:"project"`
 	// Limit will limit the number of results returned per page.
 	Limit int `q:"limit"`
-	// UUIDs will only return domains with the specified UUIDs.
-	UUIDs []string `q:"uuids"`
 }
 
-// ToDomainListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToDomainListQuery() (string, error) {
+// ToZoneListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToZoneListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-// List returns a Pager which allows you to iterate over a collection of
-// domains.
+// List returns a Pager which allows you to iterate over a collection of zones.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	serviceURL := listURL(client)
 	if opts != nil {
-		query, err := opts.ToDomainListQuery()
+		query, err := opts.ToZoneListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
@@ -55,7 +60,7 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	return pagination.NewPager(client, serviceURL, v1.CreatePage())
 }
 
-// Get retrieves a specific domain based on its unique ID.
+// Get retrieves a specific zone based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
 	resp, err := c.Get(getURL(c, id), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},

--- a/metis/v1/network/dns/results.go
+++ b/metis/v1/network/dns/results.go
@@ -1,0 +1,83 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+)
+
+type Zone struct {
+	UUID               string            `json:"uuid,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	Email              string            `json:"email,omitempty"`
+	Serial             int               `json:"serial,omitempty"`
+	ParentZoneID       string            `json:"parentZoneId,omitempty"`
+	ParentZoneName     string            `json:"parentZoneName,omitempty"`
+	Pool               string            `json:"pool,omitempty"`
+	PoolDescription    string            `json:"poolDescription,omitempty"`
+	TTL                int               `json:"ttl,omitempty"`
+	Status             string            `json:"status,omitempty"`
+	Action             string            `json:"action,omitempty"`
+	Type               string            `json:"type,omitempty"`
+	Attributes         map[string]string `json:"attributes,omitempty"`
+	SharedWithProjects []string          `json:"sharedWithProjects,omitempty"`
+	ProjectID          string            `json:"projectId,omitempty"`
+	ProjectName        string            `json:"projectName,omitempty"`
+	DomainID           string            `json:"domainId,omitempty"`
+	DomainName         string            `json:"domainName,omitempty"`
+	CreatedAt          string            `json:"createdAt,omitempty"`
+	UpdatedAt          string            `json:"updatedAt,omitempty"`
+}
+
+// Extract accepts a Page struct, specifically an v1.CommonPage struct,
+// and extracts the elements into a slice of Zone structs.
+func Extract(r pagination.Page) ([]Zone, error) {
+	var s struct {
+		Zones []Zone `json:"items"`
+	}
+	if err := (r.(v1.CommonPage)).ExtractInto(&s); err != nil {
+		return nil, err
+	}
+	return s.Zones, nil
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as a Zone.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a Zone
+// resource.
+func (r GetResult) Extract() (*Zone, error) {
+	var s struct {
+		Data struct {
+			Item Zone `json:"item"`
+		} `json:"data"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return &s.Data.Item, nil
+}
+
+func (r GetResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}

--- a/metis/v1/network/dns/testing/fixtures.go
+++ b/metis/v1/network/dns/testing/fixtures.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// HandleGetDNSZoneSuccessfully creates an HTTP handler at `/network/dns/zone/:zone_id` on the
+// test handler mux that responds with a single DNS zone.
+func HandleGetDNSZoneSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network/dns/zone/004321e142604754a789dd9b23db3242", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		jsonBytes, err := os.ReadFile(filepath.Join("fixtures", "get.json"))
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}
+
+// HandleListDNSZonesSuccessfully creates an HTTP handler at `/network/dns/zone` on the
+// test handler mux that responds with a list of DNS zones.
+func HandleListDNSZonesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network/dns/zone", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var jsonBytes []byte
+		var err error
+
+		switch r.URL.Query().Has("limit") && !r.URL.Query().Has("cursor") {
+		case true:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list_with_next.json"))
+			th.AssertNoErr(t, err)
+
+			var resp struct {
+				APIVersion string         `json:"apiVersion"`
+				Data       map[string]any `json:"data"`
+			}
+			err = json.Unmarshal(jsonBytes, &resp)
+			th.AssertNoErr(t, err)
+			// adding a nextLink to the pagination response
+			resp.Data["nextLink"] = th.Endpoint() + "/network/dns/zone?cursor=dummycursor&limit=1"
+			jsonBytes, err = json.Marshal(resp)
+		default:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list.json"))
+		}
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}

--- a/metis/v1/network/dns/testing/fixtures/get.json
+++ b/metis/v1/network/dns/testing/fixtures/get.json
@@ -1,0 +1,33 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "zone",
+    "region": "germany",
+    "item": {
+      "uuid": "004321e142604754a789dd9b23db3242",
+      "name": "test-regression.germany.cloud.de.",
+      "email": "test.user@cloud.de",
+      "serial": 1680176469,
+      "parentZoneId": "831905c1640146358f69d58437a2a042",
+      "parentZoneName": "germany.cloud.de.",
+      "pool": "default",
+      "poolDescription": "Bind9 Pool",
+      "ttl": 7200,
+      "status": "ACTIVE",
+      "action": "NONE",
+      "type": "PRIMARY",
+      "attributes": {
+        "pool_id": "794ccc2c-d75e-1337-b57f-8894c9f5c842"
+      },
+      "sharedWithProjects": [
+        "97a92f9cea1337c8a3c3bbe01caa842e"
+      ],
+      "projectId": "97a92f9cea4644c8a3c3bbe01caa842e",
+      "projectName": "regression",
+      "domainId": "8395b48e21337b8a827cc76b5fcf1c8",
+      "domainName": "test",
+      "createdAt": "2022-04-04 07:41:42",
+      "updatedAt": "2023-03-30 11:41:41"
+    }
+  }
+}

--- a/metis/v1/network/dns/testing/fixtures/list.json
+++ b/metis/v1/network/dns/testing/fixtures/list.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "zone",
+    "region": "germany",
+    "items": [
+      {
+        "uuid": "17374100fd4b4e72b94353fc1931a920",
+        "name": "hermestest.test.com.",
+        "description": "hermes test",
+        "email": "user.test@cloud.de",
+        "serial": 1688691690,
+        "pool": "default",
+        "poolDescription": "Bind9 Pool",
+        "ttl": 7200,
+        "status": "ACTIVE",
+        "action": "NONE",
+        "type": "PRIMARY",
+        "attributes": {
+          "pool_id": "794ccc2c-d751-44fe-b57f-1337c9f5c842"
+        },
+        "sharedWithProjects": [
+          "97a92f9cea1337c8a3c3bbe01caa842e"
+        ],
+        "projectId": "e9141fb24eee4b3e9f25ae69cda31142",
+        "projectName": "demo",
+        "domainId": "2bac466eed364d8a92e477459e901337",
+        "domainName": "admin",
+        "createdAt": "2019-10-14 14:15:18",
+        "updatedAt": "2023-07-07 01:01:23"
+      }
+    ]
+  }
+}

--- a/metis/v1/network/dns/testing/fixtures/list_with_next.json
+++ b/metis/v1/network/dns/testing/fixtures/list_with_next.json
@@ -1,0 +1,32 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "zone",
+    "region": "germany",
+    "items": [
+      {
+        "uuid": "004321e142604754a789dd9b23db3242",
+        "name": "test-regression.germany.cloud.de.",
+        "email": "test.user@cloud.de",
+        "serial": 1680176469,
+        "parentZoneId": "831905c1640146358f69d58437a2a042",
+        "parentZoneName": "germany.cloud.de.",
+        "pool": "default",
+        "poolDescription": "Bind9 Pool",
+        "ttl": 7200,
+        "status": "ACTIVE",
+        "action": "NONE",
+        "type": "PRIMARY",
+        "attributes": {
+          "pool_id": "794ccc2c-d75e-1337-b57f-8894c9f5c842"
+        },
+        "projectId": "97a92f9cea4644c8a3c3bbe01caa842e",
+        "projectName": "regression",
+        "domainId": "8395b48e21337b8a827cc76b5fcf1c8",
+        "domainName": "test",
+        "createdAt": "2022-04-04 07:41:42",
+        "updatedAt": "2023-03-30 11:41:41"
+      }
+    ]
+  }
+}

--- a/metis/v1/network/dns/testing/requests_test.go
+++ b/metis/v1/network/dns/testing/requests_test.go
@@ -1,0 +1,128 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
+
+	"github.com/sapcc/gophercloud-sapcc/metis/v1/network/dns"
+)
+
+func TestGetDNSZone(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetDNSZoneSuccessfully(t)
+
+	actual, err := dns.Get(fakeclient.ServiceClient(), "004321e142604754a789dd9b23db3242").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &dns.Zone{
+		UUID:            "004321e142604754a789dd9b23db3242",
+		Name:            "test-regression.germany.cloud.de.",
+		Email:           "test.user@cloud.de",
+		Serial:          1680176469,
+		ParentZoneID:    "831905c1640146358f69d58437a2a042",
+		ParentZoneName:  "germany.cloud.de.",
+		Pool:            "default",
+		PoolDescription: "Bind9 Pool",
+		TTL:             7200,
+		Status:          "ACTIVE",
+		Action:          "NONE",
+		Type:            "PRIMARY",
+		Attributes: map[string]string{
+			"pool_id": "794ccc2c-d75e-1337-b57f-8894c9f5c842",
+		},
+		SharedWithProjects: []string{
+			"97a92f9cea1337c8a3c3bbe01caa842e",
+		},
+		ProjectID:   "97a92f9cea4644c8a3c3bbe01caa842e",
+		ProjectName: "regression",
+		DomainID:    "8395b48e21337b8a827cc76b5fcf1c8",
+		DomainName:  "test",
+		CreatedAt:   "2022-04-04 07:41:42",
+		UpdatedAt:   "2023-03-30 11:41:41",
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestListDNSZones(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListDNSZonesSuccessfully(t)
+
+	opts := dns.ListOpts{Limit: 1}
+
+	p, err := dns.List(fakeclient.ServiceClient(), opts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := dns.Extract(p)
+	th.AssertNoErr(t, err)
+
+	expected := []dns.Zone{
+		{
+			UUID:            "004321e142604754a789dd9b23db3242",
+			Name:            "test-regression.germany.cloud.de.",
+			Email:           "test.user@cloud.de",
+			Serial:          1680176469,
+			ParentZoneID:    "831905c1640146358f69d58437a2a042",
+			ParentZoneName:  "germany.cloud.de.",
+			Pool:            "default",
+			PoolDescription: "Bind9 Pool",
+			TTL:             7200,
+			Status:          "ACTIVE",
+			Action:          "NONE",
+			Type:            "PRIMARY",
+			Attributes: map[string]string{
+				"pool_id": "794ccc2c-d75e-1337-b57f-8894c9f5c842",
+			},
+			ProjectID:   "97a92f9cea4644c8a3c3bbe01caa842e",
+			ProjectName: "regression",
+			DomainID:    "8395b48e21337b8a827cc76b5fcf1c8",
+			DomainName:  "test",
+			CreatedAt:   "2022-04-04 07:41:42",
+			UpdatedAt:   "2023-03-30 11:41:41",
+		},
+		{
+			UUID:            "17374100fd4b4e72b94353fc1931a920",
+			Name:            "hermestest.test.com.",
+			Description:     "hermes test",
+			Email:           "user.test@cloud.de",
+			Serial:          1688691690,
+			Pool:            "default",
+			PoolDescription: "Bind9 Pool",
+			TTL:             7200,
+			Status:          "ACTIVE",
+			Action:          "NONE",
+			Type:            "PRIMARY",
+			Attributes: map[string]string{
+				"pool_id": "794ccc2c-d751-44fe-b57f-1337c9f5c842",
+			},
+			SharedWithProjects: []string{
+				"97a92f9cea1337c8a3c3bbe01caa842e",
+			},
+			ProjectID:   "e9141fb24eee4b3e9f25ae69cda31142",
+			ProjectName: "demo",
+			DomainID:    "2bac466eed364d8a92e477459e901337",
+			DomainName:  "admin",
+			CreatedAt:   "2019-10-14 14:15:18",
+			UpdatedAt:   "2023-07-07 01:01:23",
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/metis/v1/network/dns/urls.go
+++ b/metis/v1/network/dns/urls.go
@@ -1,0 +1,25 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("network", "dns", "zone")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("network", "dns", "zone", id)
+}

--- a/metis/v1/network/ip/requests.go
+++ b/metis/v1/network/ip/requests.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package domains
+package ip
 
 import (
 	"github.com/gophercloud/gophercloud"
@@ -24,29 +24,34 @@ import (
 // ListOptsBuilder allows extensions to add additional parameters to the
 // List request.
 type ListOptsBuilder interface {
-	ToDomainListQuery() (string, error)
+	ToIPAddressListQuery() (string, error)
 }
 
-// ListOpts is a structure that holds options for listing domain masterdata.
+// ListOpts is a structure that holds options for listing ipaddresses.
 type ListOpts struct {
+	// IPAddresses will only return ipaddresses with the specified UUIDs.
+	IPAddresses []string `q:"ip"`
+	// CIDR will only return ipaddresses with the specified CIDR.
+	CIDR []string `q:"cidr"`
+	// DomainID will only return ipaddresses with the specified DomainID.
+	DomainID string `q:"domain"`
+	// ProjectID will only return ipaddresses with the specified ProjectID.
+	ProjectID string `q:"project"`
 	// Limit will limit the number of results returned per page.
 	Limit int `q:"limit"`
-	// UUIDs will only return domains with the specified UUIDs.
-	UUIDs []string `q:"uuids"`
 }
 
-// ToDomainListQuery formats a ListOpts into a query string.
-func (opts ListOpts) ToDomainListQuery() (string, error) {
+// ToIPAddressListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToIPAddressListQuery() (string, error) {
 	q, err := gophercloud.BuildQueryString(opts)
 	return q.String(), err
 }
 
-// List returns a Pager which allows you to iterate over a collection of
-// domains.
+// List returns a Pager which allows you to iterate over a collection of ipadresses.
 func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	serviceURL := listURL(client)
 	if opts != nil {
-		query, err := opts.ToDomainListQuery()
+		query, err := opts.ToIPAddressListQuery()
 		if err != nil {
 			return pagination.Pager{Err: err}
 		}
@@ -55,9 +60,9 @@ func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pa
 	return pagination.NewPager(client, serviceURL, v1.CreatePage())
 }
 
-// Get retrieves a specific domain based on its unique ID.
-func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
-	resp, err := c.Get(getURL(c, id), &r.Body, &gophercloud.RequestOpts{
+// Get retrieves a specific ipaddress.
+func Get(c *gophercloud.ServiceClient, ipaddress string) (r GetResult) {
+	resp, err := c.Get(getURL(c, ipaddress), &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)

--- a/metis/v1/network/ip/results.go
+++ b/metis/v1/network/ip/results.go
@@ -1,0 +1,80 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+
+	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+)
+
+type IPAddress struct {
+	IP          string `json:"ipaddress"`
+	PortUUID    string `json:"port"`
+	Description string `json:"description,omitempty"`
+	Status      string `json:"status,omitempty"`
+	DeviceID    string `json:"deviceID,omitempty"`
+	DeviceOwner string `json:"deviceOwner,omitempty"`
+	FixedPortID string `json:"fixedPortID,omitempty"`
+	FixedIP     string `json:"fixedIP,omitempty"`
+	NetworkID   string `json:"networkID,omitempty"`
+	NetworkName string `json:"networkName,omitempty"`
+	SubnetID    string `json:"subnetID,omitempty"`
+	SubnetName  string `json:"subnetName,omitempty"`
+	DomainID    string `json:"domainID,omitempty"`
+	DomainName  string `json:"domainName,omitempty"`
+	ProjectID   string `json:"projectID,omitempty"`
+	ProjectName string `json:"projectName,omitempty"`
+	Created     string `json:"created,omitempty"`
+	LastChanged string `json:"lastChanged,omitempty"`
+}
+
+// Extract accepts a Page struct, specifically an v1.CommonPage struct,
+// and extracts the elements into a slice of IPAddress structs.
+func Extract(r pagination.Page) ([]IPAddress, error) {
+	var s struct {
+		IPAdresses []IPAddress `json:"items"`
+	}
+	if err := (r.(v1.CommonPage)).ExtractInto(&s); err != nil {
+		return nil, err
+	}
+	return s.IPAdresses, nil
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as a IPAddress.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a IPAddress
+// resource.
+func (r GetResult) Extract() (*IPAddress, error) {
+	var s struct {
+		Data struct {
+			Item IPAddress `json:"item"`
+		} `json:"data"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return &s.Data.Item, nil
+}
+
+func (r GetResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "")
+}

--- a/metis/v1/network/ip/testing/fixtures.go
+++ b/metis/v1/network/ip/testing/fixtures.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+// HandleGetIPAddressSuccessfully creates an HTTP handler at `/network/ip/:ipaddress` on the
+// test handler mux that responds with a single ipaddress.
+func HandleGetIPAddressSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network/ip/10.216.24.194", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		jsonBytes, err := os.ReadFile(filepath.Join("fixtures", "get.json"))
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}
+
+// HandleListIPAddressesSuccessfully creates an HTTP handler at `/network/ip` on the
+// test handler mux that responds with a list of ipaddresses.
+func HandleListIPAddressesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network/ip", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var jsonBytes []byte
+		var err error
+
+		switch r.URL.Query().Has("limit") && !r.URL.Query().Has("cursor") {
+		case true:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list_with_next.json"))
+			th.AssertNoErr(t, err)
+
+			var resp struct {
+				APIVersion string         `json:"apiVersion"`
+				Data       map[string]any `json:"data"`
+			}
+			err = json.Unmarshal(jsonBytes, &resp)
+			th.AssertNoErr(t, err)
+			// adding a nextLink to the pagination response
+			resp.Data["nextLink"] = th.Endpoint() + "/network/ip?cursor=dummycursor&limit=1"
+			jsonBytes, err = json.Marshal(resp)
+		default:
+			jsonBytes, err = os.ReadFile(filepath.Join("fixtures", "list.json"))
+		}
+		th.AssertNoErr(t, err)
+		w.Write(jsonBytes) //nolint:errcheck
+	})
+}

--- a/metis/v1/network/ip/testing/fixtures/get.json
+++ b/metis/v1/network/ip/testing/fixtures/get.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "ipaddress",
+    "region": "germany",
+    "item": {
+      "ipaddress": "10.216.24.194",
+      "port": "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+      "description": "",
+      "status": "ACTIVE",
+      "deviceID": "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+      "deviceOwner": "network:dhcp",
+      "networkID": "1563904c-ac3d-1337-994a-676d9a1716c6",
+      "networkName": "network-name",
+      "subnetID": "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+      "subnetName": "subnet-name",
+      "domainID": "666da95112694b37b3efb0913de31337",
+      "domainName": "admin",
+      "projectID": "0420083ad7d145dc9fdb9ccdb59ad5b6",
+      "projectName": "admin-net-infra",
+      "created": "2019-08-12 09:22:54",
+      "lastChanged": "2023-08-10 14:26:51"
+    }
+  }
+}

--- a/metis/v1/network/ip/testing/fixtures/list.json
+++ b/metis/v1/network/ip/testing/fixtures/list.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "ipaddress",
+    "region": "germany",
+    "items": [
+      {
+        "ipaddress": "192.0.0.1",
+        "port": "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+        "description": "dummy",
+        "status": "ACTIVE",
+        "deviceID": "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+        "deviceOwner": "network:dhcp",
+        "networkID": "1563904c-ac3d-1337-994a-676d9a1716c6",
+        "networkName": "network-name",
+        "subnetID": "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+        "subnetName": "subnet-name",
+        "domainID": "666da95112694b37b3efb0913de31337",
+        "domainName": "admin",
+        "projectID": "0420083ad7d145dc9fdb9ccdb59ad5b6",
+        "projectName": "admin-net-infra",
+        "created": "2019-08-12 09:22:54",
+        "lastChanged": "2023-08-10 14:26:51"
+      }
+    ]
+  }
+}

--- a/metis/v1/network/ip/testing/fixtures/list_with_next.json
+++ b/metis/v1/network/ip/testing/fixtures/list_with_next.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "1.0",
+  "data": {
+    "kind": "ipaddress",
+    "region": "germany",
+    "items": [
+      {
+        "ipaddress": "127.0.0.1",
+        "port": "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+        "description": "test",
+        "status": "ACTIVE",
+        "deviceID": "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+        "deviceOwner": "network:dhcp",
+        "networkID": "1563904c-ac3d-1337-994a-676d9a1716c6",
+        "networkName": "network-name",
+        "subnetID": "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+        "subnetName": "subnet-name",
+        "domainID": "666da95112694b37b3efb0913de31337",
+        "domainName": "admin",
+        "projectID": "0420083ad7d145dc9fdb9ccdb59ad5b6",
+        "projectName": "admin-net-infra",
+        "created": "2019-08-12 09:22:54",
+        "lastChanged": "2023-08-10 14:26:51"
+      }
+    ]
+  }
+}

--- a/metis/v1/network/ip/testing/requests_test.go
+++ b/metis/v1/network/ip/testing/requests_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/testhelper/client"
+
+	"github.com/sapcc/gophercloud-sapcc/metis/v1/network/ip"
+)
+
+func TestGetProject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetIPAddressSuccessfully(t)
+
+	actual, err := ip.Get(fakeclient.ServiceClient(), "10.216.24.194").Extract()
+	th.AssertNoErr(t, err)
+
+	expected := &ip.IPAddress{
+		IP:          "10.216.24.194",
+		PortUUID:    "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+		Description: "",
+		Status:      "ACTIVE",
+		DeviceID:    "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+		DeviceOwner: "network:dhcp",
+		NetworkID:   "1563904c-ac3d-1337-994a-676d9a1716c6",
+		NetworkName: "network-name",
+		SubnetID:    "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+		SubnetName:  "subnet-name",
+		DomainID:    "666da95112694b37b3efb0913de31337",
+		DomainName:  "admin",
+		ProjectID:   "0420083ad7d145dc9fdb9ccdb59ad5b6",
+		ProjectName: "admin-net-infra",
+		Created:     "2019-08-12 09:22:54",
+		LastChanged: "2023-08-10 14:26:51",
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+}
+
+func TestListProjects(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListIPAddressesSuccessfully(t)
+
+	opts := ip.ListOpts{Limit: 1}
+
+	p, err := ip.List(fakeclient.ServiceClient(), opts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := ip.Extract(p)
+	th.AssertNoErr(t, err)
+
+	expected := []ip.IPAddress{
+		{
+			IP:          "127.0.0.1",
+			PortUUID:    "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+			Description: "test",
+			Status:      "ACTIVE",
+			DeviceID:    "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+			DeviceOwner: "network:dhcp",
+			NetworkID:   "1563904c-ac3d-1337-994a-676d9a1716c6",
+			NetworkName: "network-name",
+			SubnetID:    "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+			SubnetName:  "subnet-name",
+			DomainID:    "666da95112694b37b3efb0913de31337",
+			DomainName:  "admin",
+			ProjectID:   "0420083ad7d145dc9fdb9ccdb59ad5b6",
+			ProjectName: "admin-net-infra",
+			Created:     "2019-08-12 09:22:54",
+			LastChanged: "2023-08-10 14:26:51",
+		}, {
+			IP:          "192.0.0.1",
+			PortUUID:    "9cf53dfa-8a72-1337-bf69-523d11ffccb9",
+			Description: "dummy",
+			Status:      "ACTIVE",
+			DeviceID:    "dhcp5d784bae-4201-530e-90df-393914f8601b-1563904c-ac3d-4281-994a-676d9a1716c6",
+			DeviceOwner: "network:dhcp",
+			NetworkID:   "1563904c-ac3d-1337-994a-676d9a1716c6",
+			NetworkName: "network-name",
+			SubnetID:    "e6f6ff0c-42fa-1337-9e78-2a8405fed887",
+			SubnetName:  "subnet-name",
+			DomainID:    "666da95112694b37b3efb0913de31337",
+			DomainName:  "admin",
+			ProjectID:   "0420083ad7d145dc9fdb9ccdb59ad5b6",
+			ProjectName: "admin-net-infra",
+			Created:     "2019-08-12 09:22:54",
+			LastChanged: "2023-08-10 14:26:51",
+		}}
+
+	th.CheckDeepEquals(t, expected, actual)
+}

--- a/metis/v1/network/ip/urls.go
+++ b/metis/v1/network/ip/urls.go
@@ -1,0 +1,25 @@
+// Copyright 2023 SAP SE
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("network", "ip")
+}
+
+func getURL(c *gophercloud.ServiceClient, ipaddress string) string {
+	return c.ServiceURL("network", "ip", ipaddress)
+}


### PR DESCRIPTION
This adds handlers to the Metis client to access the endpoints for IPAddresses and DNSZones