### PR TITLE
Fix v2 package names in tests

### DIFF
--- a/arc/v1/agents/results.go
+++ b/arc/v1/agents/results.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	"github.com/sapcc/gophercloud-sapcc/util"
+	"github.com/sapcc/gophercloud-sapcc/v2/util"
 )
 
 const (

--- a/arc/v1/agents/testing/requests_test.go
+++ b/arc/v1/agents/testing/requests_test.go
@@ -26,7 +26,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/arc/v1/agents"
+	"github.com/sapcc/gophercloud-sapcc/v2/arc/v1/agents"
 )
 
 var agentTags = map[string]string{

--- a/arc/v1/jobs/results.go
+++ b/arc/v1/jobs/results.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	"github.com/sapcc/gophercloud-sapcc/util"
+	"github.com/sapcc/gophercloud-sapcc/v2/util"
 )
 
 const (

--- a/arc/v1/jobs/testing/requests_test.go
+++ b/arc/v1/jobs/testing/requests_test.go
@@ -26,7 +26,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/arc/v1/jobs"
+	"github.com/sapcc/gophercloud-sapcc/v2/arc/v1/jobs"
 )
 
 var jobsList = []jobs.Job{

--- a/audit/v1/events/testing/requests_test.go
+++ b/audit/v1/events/testing/requests_test.go
@@ -25,7 +25,7 @@ import (
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 	"github.com/sapcc/go-api-declarations/cadf"
 
-	"github.com/sapcc/gophercloud-sapcc/audit/v1/events"
+	"github.com/sapcc/gophercloud-sapcc/v2/audit/v1/events"
 )
 
 var eventsList = []events.Event{

--- a/automation/v1/automations/results.go
+++ b/automation/v1/automations/results.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	"github.com/sapcc/gophercloud-sapcc/util"
+	"github.com/sapcc/gophercloud-sapcc/v2/util"
 )
 
 const (

--- a/automation/v1/automations/testing/requests_test.go
+++ b/automation/v1/automations/testing/requests_test.go
@@ -26,7 +26,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/automations"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/automations"
 )
 
 var automationsList = []automations.Automation{

--- a/automation/v1/runs/results.go
+++ b/automation/v1/runs/results.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	"github.com/sapcc/gophercloud-sapcc/util"
+	"github.com/sapcc/gophercloud-sapcc/v2/util"
 )
 
 const (

--- a/automation/v1/runs/testing/requests_test.go
+++ b/automation/v1/runs/testing/requests_test.go
@@ -26,7 +26,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/runs"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/runs"
 )
 
 var RunObject = runs.Run{

--- a/billing/masterdata/domains/testing/requests_test.go
+++ b/billing/masterdata/domains/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/masterdata/domains"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/domains"
 )
 
 var domainsList = []domains.Domain{

--- a/billing/masterdata/price/testing/requests_test.go
+++ b/billing/masterdata/price/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/masterdata/price"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/price"
 )
 
 var priceList = []price.Price{

--- a/billing/masterdata/projects/testing/requests_test.go
+++ b/billing/masterdata/projects/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/masterdata/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/projects"
 )
 
 var projectsList = []projects.Project{

--- a/billing/services/billing/testing/requests_test.go
+++ b/billing/services/billing/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/services/billing"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/services/billing"
 )
 
 var billingList = []billing.Billing{

--- a/billing/services/costing/testing/requests_test.go
+++ b/billing/services/costing/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fake "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/services/costing"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/services/costing"
 )
 
 var costingList = []costing.Costing{

--- a/internal/acceptance/arc/v1/agents.go
+++ b/internal/acceptance/arc/v1/agents.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/arc/v1/agents"
+	"github.com/sapcc/gophercloud-sapcc/v2/arc/v1/agents"
 )
 
 // CreateAgent will bootstrap an arc agent. An error will be returned if the

--- a/internal/acceptance/arc/v1/agents_test.go
+++ b/internal/acceptance/arc/v1/agents_test.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/arc/v1/agents"
+	"github.com/sapcc/gophercloud-sapcc/v2/arc/v1/agents"
 )
 
 func TestAgentInit(t *testing.T) {

--- a/internal/acceptance/arc/v1/client.go
+++ b/internal/acceptance/arc/v1/client.go
@@ -19,12 +19,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/clients"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/clients"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 
-	cc_clients "github.com/sapcc/gophercloud-sapcc/clients"
+	cc_clients "github.com/sapcc/gophercloud-sapcc/v2/clients"
 )
 
 // configureDebug will configure the provider client to print the API

--- a/internal/acceptance/audit/v1/client.go
+++ b/internal/acceptance/audit/v1/client.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gophercloud/utils/v2/client"
 	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 
-	"github.com/sapcc/gophercloud-sapcc/clients"
+	"github.com/sapcc/gophercloud-sapcc/v2/clients"
 )
 
 // configureDebug will configure the provider client to print the API

--- a/internal/acceptance/audit/v1/events_test.go
+++ b/internal/acceptance/audit/v1/events_test.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/audit/v1/events"
+	"github.com/sapcc/gophercloud-sapcc/v2/audit/v1/events"
 )
 
 func TestEventList(t *testing.T) {

--- a/internal/acceptance/automation/v1/automations.go
+++ b/internal/acceptance/automation/v1/automations.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
 	"github.com/gophercloud/gophercloud/v2"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/automations"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/automations"
 )
 
 // CreateChefAutomation will create a Chef automation. An error will be

--- a/internal/acceptance/automation/v1/automations_test.go
+++ b/internal/acceptance/automation/v1/automations_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/automations"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/automations"
 )
 
 func TestAutomationCRUD(t *testing.T) {

--- a/internal/acceptance/automation/v1/client.go
+++ b/internal/acceptance/automation/v1/client.go
@@ -19,12 +19,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/clients"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/clients"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 
-	cc_clients "github.com/sapcc/gophercloud-sapcc/clients"
+	cc_clients "github.com/sapcc/gophercloud-sapcc/v2/clients"
 )
 
 // configureDebug will configure the provider client to print the API

--- a/internal/acceptance/automation/v1/runs.go
+++ b/internal/acceptance/automation/v1/runs.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/runs"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/runs"
 )
 
 // CreateRun will create an automation run. An error will be

--- a/internal/acceptance/automation/v1/runs_test.go
+++ b/internal/acceptance/automation/v1/runs_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/automations"
-	"github.com/sapcc/gophercloud-sapcc/automation/v1/runs"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/automations"
+	"github.com/sapcc/gophercloud-sapcc/v2/automation/v1/runs"
 )
 
 func TestRunCR(t *testing.T) {

--- a/internal/acceptance/clients/http.go
+++ b/internal/acceptance/clients/http.go
@@ -1,5 +1,5 @@
 // copied from upstream to bypass internal package
-// https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/internal/acceptance/clients/http.go
+// https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/clients/http.go
 package clients
 
 import (

--- a/internal/acceptance/masterdata/billing/client.go
+++ b/internal/acceptance/masterdata/billing/client.go
@@ -19,13 +19,13 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/clients"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/clients"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 
-	cc_clients "github.com/sapcc/gophercloud-sapcc/clients"
+	cc_clients "github.com/sapcc/gophercloud-sapcc/v2/clients"
 )
 
 // configureDebug will configure the provider client to print the API

--- a/internal/acceptance/masterdata/billing/projects.go
+++ b/internal/acceptance/masterdata/billing/projects.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/masterdata/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/projects"
 )
 
 func getIntField(v interface{}, field string) int {

--- a/internal/acceptance/masterdata/billing/projects_test.go
+++ b/internal/acceptance/masterdata/billing/projects_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools"
+	"github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools"
 
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/billing/masterdata/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/projects"
 )
 
 var projectID = "3e0fd3f8e9ec449686ef26a16a284265"

--- a/internal/acceptance/tools/tools.go
+++ b/internal/acceptance/tools/tools.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// copied from https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools/tools.go#L48-L60
+// copied from https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools/tools.go#L48-L60
 // RandomString generates a string of given length, but random content.
 // All content will be within the ASCII graphic character set.
 // (Implementation from Even Shaw's contribution on
@@ -22,7 +22,7 @@ func RandomString(prefix string, n int) string {
 	return prefix + string(bytes)
 }
 
-// copied from https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/internal/acceptance/tools/tools.go#L77-L81
+// copied from https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools/tools.go#L77-L81
 // PrintResource returns a resource as a readable structure
 func PrintResource(t *testing.T, resource interface{}) {
 	b, _ := json.MarshalIndent(resource, "", "  ")

--- a/metis/v1/identity/costobjects/requests.go
+++ b/metis/v1/identity/costobjects/requests.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/metis/v1/identity/costobjects/results.go
+++ b/metis/v1/identity/costobjects/results.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 type CostObject struct {

--- a/metis/v1/identity/costobjects/testing/requests_test.go
+++ b/metis/v1/identity/costobjects/testing/requests_test.go
@@ -21,7 +21,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/metis/v1/identity/costobjects"
+	"github.com/sapcc/gophercloud-sapcc/v2/metis/v1/identity/costobjects"
 )
 
 func TestGetProject(t *testing.T) {

--- a/metis/v1/identity/domains/requests.go
+++ b/metis/v1/identity/domains/requests.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/metis/v1/identity/domains/results.go
+++ b/metis/v1/identity/domains/results.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // Domain represents a OpenStack domain with attached Billing Metadata.

--- a/metis/v1/identity/domains/testing/requests_test.go
+++ b/metis/v1/identity/domains/testing/requests_test.go
@@ -21,7 +21,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/metis/v1/identity/domains"
+	"github.com/sapcc/gophercloud-sapcc/v2/metis/v1/identity/domains"
 )
 
 func TestGetDomain(t *testing.T) {

--- a/metis/v1/identity/projects/requests.go
+++ b/metis/v1/identity/projects/requests.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/metis/v1/identity/projects/results.go
+++ b/metis/v1/identity/projects/results.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // Project represents a Keystone project.

--- a/metis/v1/identity/projects/testing/requests_test.go
+++ b/metis/v1/identity/projects/testing/requests_test.go
@@ -21,7 +21,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/metis/v1/identity/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/metis/v1/identity/projects"
 )
 
 func TestGetProject(t *testing.T) {

--- a/metis/v1/network/dns/requests.go
+++ b/metis/v1/network/dns/requests.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/metis/v1/network/dns/results.go
+++ b/metis/v1/network/dns/results.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 type Zone struct {

--- a/metis/v1/network/dns/testing/requests_test.go
+++ b/metis/v1/network/dns/testing/requests_test.go
@@ -21,7 +21,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/metis/v1/network/dns"
+	"github.com/sapcc/gophercloud-sapcc/v2/metis/v1/network/dns"
 )
 
 func TestGetDNSZone(t *testing.T) {

--- a/metis/v1/network/ip/requests.go
+++ b/metis/v1/network/ip/requests.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/metis/v1/network/ip/results.go
+++ b/metis/v1/network/ip/results.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 
-	v1 "github.com/sapcc/gophercloud-sapcc/metis/v1"
+	v1 "github.com/sapcc/gophercloud-sapcc/v2/metis/v1"
 )
 
 type IPAddress struct {

--- a/metis/v1/network/ip/testing/requests_test.go
+++ b/metis/v1/network/ip/testing/requests_test.go
@@ -21,7 +21,7 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 
-	"github.com/sapcc/gophercloud-sapcc/metis/v1/network/ip"
+	"github.com/sapcc/gophercloud-sapcc/v2/metis/v1/network/ip"
 )
 
 func TestGetProject(t *testing.T) {

--- a/networking/v2/bgpvpn/interconnections/testing/fixture.go
+++ b/networking/v2/bgpvpn/interconnections/testing/fixture.go
@@ -14,7 +14,7 @@
 
 package testing
 
-import "github.com/sapcc/gophercloud-sapcc/networking/v2/bgpvpn/interconnections"
+import "github.com/sapcc/gophercloud-sapcc/v2/networking/v2/bgpvpn/interconnections"
 
 const ListInterconnectionsResponse = `
 {

--- a/networking/v2/bgpvpn/interconnections/testing/requests_test.go
+++ b/networking/v2/bgpvpn/interconnections/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 
-	"github.com/sapcc/gophercloud-sapcc/networking/v2/bgpvpn/interconnections"
+	"github.com/sapcc/gophercloud-sapcc/v2/networking/v2/bgpvpn/interconnections"
 )
 
 func TestList(t *testing.T) {

--- a/rates/v1/clusters/testing/requests_test.go
+++ b/rates/v1/clusters/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 
-	"github.com/sapcc/gophercloud-sapcc/rates/v1/clusters"
+	"github.com/sapcc/gophercloud-sapcc/v2/rates/v1/clusters"
 )
 
 func TestGetClusterRates(t *testing.T) {

--- a/rates/v1/projects/doc.go
+++ b/rates/v1/projects/doc.go
@@ -26,8 +26,8 @@
 //	  "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 //	  "github.com/gophercloud/utils/v2/openstack/clientconfig"
 //
-//	  "github.com/sapcc/gophercloud-sapcc/clients"
-//	  "github.com/sapcc/gophercloud-sapcc/rates/v1/projects"
+//	  "github.com/sapcc/gophercloud-sapcc/v2/clients"
+//	  "github.com/sapcc/gophercloud-sapcc/v2/rates/v1/projects"
 //	)
 //
 //	func main() {

--- a/rates/v1/projects/testing/requests_test.go
+++ b/rates/v1/projects/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesrates "github.com/sapcc/go-api-declarations/limes/rates"
 
-	"github.com/sapcc/gophercloud-sapcc/rates/v1/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/rates/v1/projects"
 )
 
 func TestListProjectsRates(t *testing.T) {

--- a/resources/v1/clusters/testing/requests_test.go
+++ b/resources/v1/clusters/testing/requests_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 
-	"github.com/sapcc/gophercloud-sapcc/resources/v1/clusters"
+	"github.com/sapcc/gophercloud-sapcc/v2/resources/v1/clusters"
 )
 
 func TestGetCluster(t *testing.T) {

--- a/resources/v1/domains/testing/requests_test.go
+++ b/resources/v1/domains/testing/requests_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 
-	"github.com/sapcc/gophercloud-sapcc/resources/v1/domains"
+	"github.com/sapcc/gophercloud-sapcc/v2/resources/v1/domains"
 )
 
 func TestListDomain(t *testing.T) {

--- a/resources/v1/projects/doc.go
+++ b/resources/v1/projects/doc.go
@@ -26,8 +26,8 @@
 //	  "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
 //	  "github.com/gophercloud/utils/v2/openstack/clientconfig"
 //
-//	  "github.com/sapcc/gophercloud-sapcc/clients"
-//	  "github.com/sapcc/gophercloud-sapcc/resources/v1/projects"
+//	  "github.com/sapcc/gophercloud-sapcc/v2/clients"
+//	  "github.com/sapcc/gophercloud-sapcc/v2/resources/v1/projects"
 //	)
 //
 //	func main() {

--- a/resources/v1/projects/testing/requests_test.go
+++ b/resources/v1/projects/testing/requests_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sapcc/go-api-declarations/limes"
 	limesresources "github.com/sapcc/go-api-declarations/limes/resources"
 
-	"github.com/sapcc/gophercloud-sapcc/resources/v1/projects"
+	"github.com/sapcc/gophercloud-sapcc/v2/resources/v1/projects"
 )
 
 func TestListProjects(t *testing.T) {


### PR DESCRIPTION
```
find . -name '*.go' -exec sed -i 's|github.com/sapcc/gophercloud-sapcc/\([^v]\)|github.com/sapcc/gophercloud-sapcc/v2/\1|g' {} \;
```