### PR TITLE
bgpvpn: Add remote_interconnection_id update argument

### DIFF
--- a/networking/v2/bgpvpn/interconnections/requests.go
+++ b/networking/v2/bgpvpn/interconnections/requests.go
@@ -131,8 +131,9 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts represents options used to update an interconnection.
 type UpdateOpts struct {
-	Name  *string `json:"name,omitempty"`
-	State *string `json:"state,omitempty"`
+	Name                    *string `json:"name,omitempty"`
+	State                   *string `json:"state,omitempty"`
+	RemoteInterconnectionID *string `json:"remote_interconnection_id,omitempty"`
 }
 
 // ToInterconnectionUpdateMap formats an UpdateOpts into a map.


### PR DESCRIPTION
Add missing `remote_interconnection_id` update arg.
https://github.com/sapcc/networking-interconnection/blob/34046a17910df76ebe8317473aebc793c969989b/networking_interconnection/extensions/interconnection.py#L131