### PR TITLE
fix govet and modernize lints

### DIFF
--- a/arc/v1/agents/results.go
+++ b/arc/v1/agents/results.go
@@ -29,7 +29,7 @@ func (r GetResult) Extract() (*Agent, error) {
 	return &s, err
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -84,16 +84,16 @@ type DeleteResult struct {
 
 // Agent represents an Arc Agent.
 type Agent struct {
-	DisplayName  string                 `json:"display_name"`
-	AgentID      string                 `json:"agent_id"`
-	Project      string                 `json:"project"`
-	Organization string                 `json:"organization"`
-	Facts        map[string]interface{} `json:"facts"`
-	Tags         map[string]string      `json:"tags"`
-	CreatedAt    time.Time              `json:"created_at"`
-	UpdatedAt    time.Time              `json:"updated_at"`
-	UpdatedWith  string                 `json:"updated_with"`
-	UpdatedBy    string                 `json:"updated_by"`
+	DisplayName  string            `json:"display_name"`
+	AgentID      string            `json:"agent_id"`
+	Project      string            `json:"project"`
+	Organization string            `json:"organization"`
+	Facts        map[string]any    `json:"facts"`
+	Tags         map[string]string `json:"tags"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	UpdatedWith  string            `json:"updated_with"`
+	UpdatedBy    string            `json:"updated_by"`
 }
 
 func (r *Agent) UnmarshalJSON(b []byte) error {
@@ -164,7 +164,7 @@ func ExtractAgents(r pagination.Page) ([]Agent, error) {
 	return s, err
 }
 
-func ExtractAgentsInto(r pagination.Page, v interface{}) error {
+func ExtractAgentsInto(r pagination.Page, v any) error {
 	return r.(AgentPage).ExtractIntoSlicePtr(v, "")
 }
 
@@ -189,7 +189,7 @@ func (r TagsResult) Extract() (map[string]string, error) {
 	return s, err
 }
 
-type Facts map[string]interface{}
+type Facts map[string]any
 
 // FactsResult is the result of a facts request. Call its Extract method
 // to interpret it as a map[string]string.
@@ -198,7 +198,7 @@ type FactsResult struct {
 }
 
 // Extract interprets any FactsResult as map[string]string.
-func (r FactsResult) Extract() (map[string]interface{}, error) {
+func (r FactsResult) Extract() (map[string]any, error) {
 	var s Facts
 	err := r.ExtractInto(&s)
 	return s, err

--- a/arc/v1/agents/testing/requests_test.go
+++ b/arc/v1/agents/testing/requests_test.go
@@ -23,8 +23,8 @@ var agentTags = map[string]string{
 	"landscape": "staging",
 }
 
-var agentFacts = map[string]interface{}{
-	"agents": map[string]interface{}{
+var agentFacts = map[string]any{
+	"agents": map[string]any{
 		"chef":    "enabled",
 		"execute": "enabled",
 		"rpc":     "enabled",

--- a/arc/v1/jobs/requests.go
+++ b/arc/v1/jobs/requests.go
@@ -66,7 +66,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
-	ToJobCreateMap() (map[string]interface{}, error)
+	ToJobCreateMap() (map[string]any, error)
 }
 
 // CreateOpts represents the attributes used when creating a new job.
@@ -83,7 +83,7 @@ type CreateOpts struct {
 }
 
 // ToJobCreateMap builds a request body from CreateOpts.
-func (opts CreateOpts) ToJobCreateMap() (map[string]interface{}, error) {
+func (opts CreateOpts) ToJobCreateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 

--- a/arc/v1/jobs/results.go
+++ b/arc/v1/jobs/results.go
@@ -29,7 +29,7 @@ func (r commonResult) Extract() (*Job, error) {
 	return &s, err
 }
 
-func (r commonResult) ExtractInto(v interface{}) error {
+func (r commonResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -177,6 +177,6 @@ func ExtractJobs(r pagination.Page) ([]Job, error) {
 	return s, err
 }
 
-func ExtractJobsInto(r pagination.Page, v interface{}) error {
+func ExtractJobsInto(r pagination.Page, v any) error {
 	return r.(JobPage).ExtractIntoSlicePtr(v, "")
 }

--- a/audit/v1/attributes/results.go
+++ b/audit/v1/attributes/results.go
@@ -32,6 +32,6 @@ func ExtractAttributes(r pagination.Page) ([]string, error) {
 	return s, err
 }
 
-func ExtractAttributesInto(r pagination.Page, v interface{}) error {
+func ExtractAttributesInto(r pagination.Page, v any) error {
 	return r.(AttributePage).ExtractIntoSlicePtr(v, "")
 }

--- a/audit/v1/events/results.go
+++ b/audit/v1/events/results.go
@@ -20,7 +20,7 @@ func (r GetResult) Extract() (*Event, error) {
 	return &s, err
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -72,6 +72,6 @@ func ExtractEvents(r pagination.Page) ([]Event, error) {
 	return s, err
 }
 
-func ExtractEventsInto(r pagination.Page, v interface{}) error {
+func ExtractEventsInto(r pagination.Page, v any) error {
 	return r.(EventPage).ExtractIntoSlicePtr(v, "events")
 }

--- a/automation/v1/automations/requests.go
+++ b/automation/v1/automations/requests.go
@@ -61,7 +61,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
-	ToAutomationCreateMap() (map[string]interface{}, error)
+	ToAutomationCreateMap() (map[string]any, error)
 }
 
 // CreateOpts represents the attributes used when creating a new automation.
@@ -82,8 +82,8 @@ type CreateOpts struct {
 	// RunList is required only, when Type is Chef
 	RunList []string `json:"run_list,omitempty"`
 	// ChefAttributes can be set only, when Type is Chef
-	ChefAttributes map[string]interface{} `json:"chef_attributes,omitempty"`
-	LogLevel       string                 `json:"log_level,omitempty"`
+	ChefAttributes map[string]any `json:"chef_attributes,omitempty"`
+	LogLevel       string         `json:"log_level,omitempty"`
 	// Debug can be set only, when Type is Chef
 	Debug bool `json:"debug,omitempty"`
 	// ChefVersion can be set only, when Type is Chef
@@ -98,7 +98,7 @@ type CreateOpts struct {
 }
 
 // ToAutomationCreateMap builds a request body from CreateOpts.
-func (opts CreateOpts) ToAutomationCreateMap() (map[string]interface{}, error) {
+func (opts CreateOpts) ToAutomationCreateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 
@@ -121,7 +121,7 @@ func Create(ctx context.Context, c *gophercloud.ServiceClient, opts CreateOptsBu
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {
-	ToAutomationUpdateMap() (map[string]interface{}, error)
+	ToAutomationUpdateMap() (map[string]any, error)
 }
 
 // UpdateOpts represents the attributes used when updating an existing
@@ -140,11 +140,11 @@ type UpdateOpts struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// Chef
-	RunList        []string               `json:"run_list,omitempty"`
-	ChefAttributes map[string]interface{} `json:"chef_attributes,omitempty"`
-	LogLevel       *string                `json:"log_level,omitempty"`
-	Debug          *bool                  `json:"debug,omitempty"`
-	ChefVersion    *string                `json:"chef_version,omitempty"`
+	RunList        []string       `json:"run_list,omitempty"`
+	ChefAttributes map[string]any `json:"chef_attributes,omitempty"`
+	LogLevel       *string        `json:"log_level,omitempty"`
+	Debug          *bool          `json:"debug,omitempty"`
+	ChefVersion    *string        `json:"chef_version,omitempty"`
 
 	// Script
 	Path        *string           `json:"path,omitempty"`
@@ -153,7 +153,7 @@ type UpdateOpts struct {
 }
 
 // ToAutomationUpdateMap builds a request body from UpdateOpts.
-func (opts UpdateOpts) ToAutomationUpdateMap() (map[string]interface{}, error) {
+func (opts UpdateOpts) ToAutomationUpdateMap() (map[string]any, error) {
 	b, err := gophercloud.BuildRequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/automation/v1/automations/results.go
+++ b/automation/v1/automations/results.go
@@ -30,7 +30,7 @@ func (r commonResult) Extract() (*Automation, error) {
 	return &s, err
 }
 
-func (r commonResult) ExtractInto(v interface{}) error {
+func (r commonResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -99,7 +99,7 @@ type Automation struct {
 	RunList []string `json:"run_list"`
 
 	// A map of Chef cookbook attributes.
-	ChefAttributes map[string]interface{} `json:"chef_attributes"`
+	ChefAttributes map[string]any `json:"chef_attributes"`
 
 	// The automation log level. Doesn't work yet.
 	LogLevel string `json:"log_level"`
@@ -191,6 +191,6 @@ func ExtractAutomations(r pagination.Page) ([]Automation, error) {
 	return s, err
 }
 
-func ExtractAutomationsInto(r pagination.Page, v interface{}) error {
+func ExtractAutomationsInto(r pagination.Page, v any) error {
 	return r.(AutomationPage).ExtractIntoSlicePtr(v, "")
 }

--- a/automation/v1/automations/testing/requests_test.go
+++ b/automation/v1/automations/testing/requests_test.go
@@ -44,7 +44,7 @@ var automationsList = []automations.Automation{
 		CreatedAt:          time.Date(2018, time.December, 27, 14, 20, 8, 521000000, time.UTC),
 		UpdatedAt:          time.Date(2018, time.December, 28, 13, 5, 52, 241000000, time.UTC),
 		RunList:            []string{"recipe[application::app]"},
-		ChefAttributes:     map[string]interface{}{},
+		ChefAttributes:     map[string]any{},
 		Debug:              true,
 		ChefVersion:        "12.22.5",
 	},

--- a/automation/v1/runs/requests.go
+++ b/automation/v1/runs/requests.go
@@ -61,7 +61,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
-	ToRunCreateMap() (map[string]interface{}, error)
+	ToRunCreateMap() (map[string]any, error)
 }
 
 // CreateOpts represents the attributes used when creating a new run.
@@ -71,7 +71,7 @@ type CreateOpts struct {
 }
 
 // ToRunCreateMap builds a request body from CreateOpts.
-func (opts CreateOpts) ToRunCreateMap() (map[string]interface{}, error) {
+func (opts CreateOpts) ToRunCreateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 

--- a/automation/v1/runs/results.go
+++ b/automation/v1/runs/results.go
@@ -29,7 +29,7 @@ func (r commonResult) Extract() (*Run, error) {
 	return &s, err
 }
 
-func (r commonResult) ExtractInto(v interface{}) error {
+func (r commonResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -55,12 +55,12 @@ type Owner struct {
 
 // Run represents a Lyra Run.
 type Run struct {
-	ID                   string      `json:"id"`
-	AutomationID         string      `json:"automation_id"`
-	AutomationName       string      `json:"automation_name"`
-	Selector             string      `json:"selector"`
-	RepositoryRevision   string      `json:"repository_revision"`
-	AutomationAttributes interface{} `json:"automation_attributes"`
+	ID                   string `json:"id"`
+	AutomationID         string `json:"automation_id"`
+	AutomationName       string `json:"automation_name"`
+	Selector             string `json:"selector"`
+	RepositoryRevision   string `json:"repository_revision"`
+	AutomationAttributes any    `json:"automation_attributes"`
 	// State could be: preparing, executing, failed, completed
 	State     string    `json:"state"`
 	Log       string    `json:"log"`
@@ -139,6 +139,6 @@ func ExtractRuns(r pagination.Page) ([]Run, error) {
 	return s, err
 }
 
-func ExtractRunsInto(r pagination.Page, v interface{}) error {
+func ExtractRunsInto(r pagination.Page, v any) error {
 	return r.(RunPage).ExtractIntoSlicePtr(v, "")
 }

--- a/automation/v1/runs/testing/requests_test.go
+++ b/automation/v1/runs/testing/requests_test.go
@@ -35,7 +35,7 @@ var RunObject = runs.Run{
 	AutomationID:   "2",
 	AutomationName: "chef",
 	Selector:       "@identity='88e5cad3-38e6-454f-b412-662cda03e7a1'",
-	AutomationAttributes: map[string]interface{}{
+	AutomationAttributes: map[string]any{
 		"name":                "chef",
 		"debug":               true,
 		"timeout":             float64(3600),

--- a/billing/masterdata/domains/requests.go
+++ b/billing/masterdata/domains/requests.go
@@ -71,7 +71,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {
-	ToDomainUpdateMap() (map[string]interface{}, error)
+	ToDomainUpdateMap() (map[string]any, error)
 }
 
 // UpdateOpts represents the attributes used when updating an existing
@@ -98,7 +98,7 @@ type UpdateOpts struct {
 }
 
 // ToDomainUpdateMap builds a request body from UpdateOpts.
-func (opts UpdateOpts) ToDomainUpdateMap() (map[string]interface{}, error) {
+func (opts UpdateOpts) ToDomainUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 

--- a/billing/masterdata/domains/results.go
+++ b/billing/masterdata/domains/results.go
@@ -23,7 +23,7 @@ func (r commonResult) Extract() (*Domain, error) {
 	return &s, err
 }
 
-func (r commonResult) ExtractInto(v interface{}) error {
+func (r commonResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -118,6 +118,6 @@ func ExtractDomains(r pagination.Page) ([]Domain, error) {
 	return s, err
 }
 
-func ExtractDomainsInto(r pagination.Page, v interface{}) error {
+func ExtractDomainsInto(r pagination.Page, v any) error {
 	return r.(DomainPage).ExtractIntoSlicePtr(v, "")
 }

--- a/billing/masterdata/price/results.go
+++ b/billing/masterdata/price/results.go
@@ -59,6 +59,6 @@ func ExtractPrices(r pagination.Page) ([]Price, error) {
 	return s, err
 }
 
-func ExtractPricesInto(r pagination.Page, v interface{}) error {
+func ExtractPricesInto(r pagination.Page, v any) error {
 	return r.(PricePage).ExtractIntoSlicePtr(v, "")
 }

--- a/billing/masterdata/projects/requests.go
+++ b/billing/masterdata/projects/requests.go
@@ -73,7 +73,7 @@ func Get(ctx context.Context, c *gophercloud.ServiceClient, id string) (r GetRes
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {
-	ToProjectUpdateMap() (map[string]interface{}, error)
+	ToProjectUpdateMap() (map[string]any, error)
 }
 
 // UpdateOpts represents the attributes used when updating an existing
@@ -181,7 +181,7 @@ func (opts UpdateOpts) MarshalJSON() ([]byte, error) {
 }
 
 // ToProjectUpdateMap builds a request body from UpdateOpts.
-func (opts UpdateOpts) ToProjectUpdateMap() (map[string]interface{}, error) {
+func (opts UpdateOpts) ToProjectUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
 }
 

--- a/billing/masterdata/projects/results.go
+++ b/billing/masterdata/projects/results.go
@@ -23,7 +23,7 @@ func (r commonResult) Extract() (*Project, error) {
 	return &s, err
 }
 
-func (r commonResult) ExtractInto(v interface{}) error {
+func (r commonResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }
 
@@ -226,6 +226,6 @@ func ExtractProjects(r pagination.Page) ([]Project, error) {
 	return s, err
 }
 
-func ExtractProjectsInto(r pagination.Page, v interface{}) error {
+func ExtractProjectsInto(r pagination.Page, v any) error {
 	return r.(ProjectPage).ExtractIntoSlicePtr(v, "")
 }

--- a/billing/services/billing/results.go
+++ b/billing/services/billing/results.go
@@ -48,6 +48,6 @@ func ExtractBillings(r pagination.Page) ([]Billing, error) {
 	return s, err
 }
 
-func ExtractBillingsInto(r pagination.Page, v interface{}) error {
+func ExtractBillingsInto(r pagination.Page, v any) error {
 	return r.(BillingPage).ExtractIntoSlicePtr(v, "")
 }

--- a/billing/services/costing/results.go
+++ b/billing/services/costing/results.go
@@ -44,6 +44,6 @@ func ExtractCostings(r pagination.Page) ([]Costing, error) {
 	return s, err
 }
 
-func ExtractCostingsInto(r pagination.Page, v interface{}) error {
+func ExtractCostingsInto(r pagination.Page, v any) error {
 	return r.(CostingPage).ExtractIntoSlicePtr(v, "")
 }

--- a/internal/acceptance/automation/v1/automations_test.go
+++ b/internal/acceptance/automation/v1/automations_test.go
@@ -36,7 +36,7 @@ func TestAutomationCRUD(t *testing.T) {
 
 	// Update Chef automation
 	newRunList := []string{"bar"}
-	chefAttributes := map[string]interface{}{"foo": "bar"}
+	chefAttributes := map[string]any{"foo": "bar"}
 	updateOpts := automations.UpdateOpts{
 		RunList:        newRunList,
 		ChefAttributes: chefAttributes,
@@ -58,7 +58,7 @@ func TestAutomationCRUD(t *testing.T) {
 	// Unset attributes from the Chef automation
 	newRevision := "dev"
 	updateOpts = automations.UpdateOpts{
-		ChefAttributes:     map[string]interface{}{},
+		ChefAttributes:     map[string]any{},
 		RepositoryRevision: &newRevision,
 	}
 
@@ -72,7 +72,7 @@ func TestAutomationCRUD(t *testing.T) {
 
 	tools.PrintResource(t, newGetAutomation)
 	th.AssertDeepEquals(t, newChefAutomation, newGetAutomation)
-	th.AssertDeepEquals(t, newChefAutomation.ChefAttributes, map[string]interface{}(nil))
+	th.AssertDeepEquals(t, newChefAutomation.ChefAttributes, map[string]any(nil))
 	th.AssertDeepEquals(t, newChefAutomation.RepositoryRevision, newRevision)
 
 	// Update Script automation

--- a/internal/acceptance/clients/http.go
+++ b/internal/acceptance/clients/http.go
@@ -107,7 +107,7 @@ func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType stri
 // formatJSON will try to pretty-format a JSON body.
 // It will also mask known fields which contain sensitive information.
 func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
-	var rawData interface{}
+	var rawData any
 
 	err := json.Unmarshal(raw, &rawData)
 	if err != nil {
@@ -115,7 +115,7 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 		return string(raw)
 	}
 
-	data, ok := rawData.(map[string]interface{})
+	data, ok := rawData.(map[string]any)
 	if !ok {
 		pretty, err := json.MarshalIndent(rawData, "", "  ")
 		if err != nil {
@@ -127,24 +127,24 @@ func (lrt *LogRoundTripper) formatJSON(raw []byte) string {
 	}
 
 	// Mask known password fields
-	if v, ok := data["auth"].(map[string]interface{}); ok {
-		if v, ok := v["identity"].(map[string]interface{}); ok {
-			if v, ok := v["password"].(map[string]interface{}); ok {
-				if v, ok := v["user"].(map[string]interface{}); ok {
+	if v, ok := data["auth"].(map[string]any); ok {
+		if v, ok := v["identity"].(map[string]any); ok {
+			if v, ok := v["password"].(map[string]any); ok {
+				if v, ok := v["user"].(map[string]any); ok {
 					v["password"] = "***"
 				}
 			}
-			if v, ok := v["application_credential"].(map[string]interface{}); ok {
+			if v, ok := v["application_credential"].(map[string]any); ok {
 				v["secret"] = "***"
 			}
-			if v, ok := v["token"].(map[string]interface{}); ok {
+			if v, ok := v["token"].(map[string]any); ok {
 				v["id"] = "***"
 			}
 		}
 	}
 
 	// Ignore the catalog
-	if v, ok := data["token"].(map[string]interface{}); ok {
+	if v, ok := data["token"].(map[string]any); ok {
 		if _, ok := v["catalog"]; ok {
 			return ""
 		}

--- a/internal/acceptance/masterdata/billing/projects.go
+++ b/internal/acceptance/masterdata/billing/projects.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sapcc/gophercloud-sapcc/v2/billing/masterdata/projects"
 )
 
-func getIntField(v interface{}, field string) int {
+func getIntField(v any, field string) int {
 	r := reflect.ValueOf(v)
 	f := reflect.Indirect(r).FieldByName(field)
 
@@ -25,7 +25,7 @@ func getIntField(v interface{}, field string) int {
 	return int(f.Int())
 }
 
-func getStrField(v interface{}, field string) string {
+func getStrField(v any, field string) string {
 	r := reflect.ValueOf(v)
 	f := reflect.Indirect(r).FieldByName(field)
 

--- a/internal/acceptance/tools/tools.go
+++ b/internal/acceptance/tools/tools.go
@@ -30,5 +30,5 @@ func RandomString(prefix string, n int) string {
 // PrintResource returns a resource as a readable structure
 func PrintResource(t *testing.T, resource any) {
 	b, _ := json.MarshalIndent(resource, "", "  ")
-	t.Logf(string(b))
+	t.Log(string(b))
 }

--- a/internal/acceptance/tools/tools.go
+++ b/internal/acceptance/tools/tools.go
@@ -28,7 +28,7 @@ func RandomString(prefix string, n int) string {
 
 // copied from https://github.com/gophercloud/gophercloud/v2/blob/v1.7.0/github.com/sapcc/gophercloud-sapcc/v2/internal/acceptance/tools/tools.go#L77-L81
 // PrintResource returns a resource as a readable structure
-func PrintResource(t *testing.T, resource interface{}) {
+func PrintResource(t *testing.T, resource any) {
 	b, _ := json.MarshalIndent(resource, "", "  ")
 	t.Logf(string(b))
 }

--- a/metis/v1/identity/costobjects/results.go
+++ b/metis/v1/identity/costobjects/results.go
@@ -48,6 +48,6 @@ func (r GetResult) Extract() (*CostObject, error) {
 	return &s.Data.Item, nil
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }

--- a/metis/v1/identity/domains/results.go
+++ b/metis/v1/identity/domains/results.go
@@ -60,6 +60,6 @@ func (r GetResult) Extract() (*Domain, error) {
 	return &s.Data.Item, nil
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }

--- a/metis/v1/identity/projects/results.go
+++ b/metis/v1/identity/projects/results.go
@@ -94,6 +94,6 @@ func (r GetResult) Extract() (*Project, error) {
 	return &s.Data.Item, nil
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }

--- a/metis/v1/identity/projects/results.go
+++ b/metis/v1/identity/projects/results.go
@@ -17,7 +17,7 @@ type Project struct {
 	Description   string        `json:"description,omitempty"`
 	DomainName    string        `json:"domainName,omitempty"`
 	DomainUUID    string        `json:"domainUUID,omitempty"`
-	CBRMasterdata CBRMasterdata `json:"cbrMasterdata,omitempty"`
+	CBRMasterdata CBRMasterdata `json:"cbrMasterdata"`
 	Users         []User        `json:"users"`
 }
 
@@ -37,7 +37,7 @@ type CBRMasterdata struct {
 	InventoryRoleEmail              string                 `json:"inventoryRoleEmail,omitempty"`
 	InfrastructureCoordinatorUserID string                 `json:"infrastructureCoordinatorUserID,omitempty"`
 	InfrastructureCoordinatorEmail  string                 `json:"infrastructureCoordinatorEmail,omitempty"`
-	ExternalCertifications          ExternalCertifications `json:"externalCertifications,omitempty"`
+	ExternalCertifications          ExternalCertifications `json:"externalCertifications"`
 	GPUEnabled                      bool                   `json:"gpuEnabled,omitempty"`
 	ContainsPIIDPPHR                bool                   `json:"containsPIIDPPHR,omitempty"`
 	ContainsExternalCustomerData    bool                   `json:"containsExternalCustomerData,omitempty"`

--- a/metis/v1/network/dns/results.go
+++ b/metis/v1/network/dns/results.go
@@ -67,6 +67,6 @@ func (r GetResult) Extract() (*Zone, error) {
 	return &s.Data.Item, nil
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }

--- a/metis/v1/network/ip/results.go
+++ b/metis/v1/network/ip/results.go
@@ -64,6 +64,6 @@ func (r GetResult) Extract() (*IPAddress, error) {
 	return &s.Data.Item, nil
 }
 
-func (r GetResult) ExtractInto(v interface{}) error {
+func (r GetResult) ExtractInto(v any) error {
 	return r.ExtractIntoStructPtr(v, "")
 }


### PR DESCRIPTION
I recommend the "Hide whitespace" option. The `s/interface{}/any/` replacement shifts a lot of indentation around.