### PR TITLE
Makefile.maker.yaml: remove Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,24 @@ jobs:
         with:
           check-latest: true
           go-version: 1.24.6
+  code_coverage:
+    name: Code coverage report
+    if: github.event_name == 'pull_request'
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+      - name: Post coverage report
+        uses: fgrosse/go-coverage-report@v1.2.0
+        with:
+          coverage-artifact-name: code-coverage
+          coverage-file-name: cover.out
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
   test:
     name: Test
     needs:
@@ -48,10 +66,8 @@ jobs:
           go-version: 1.24.6
       - name: Run tests and generate coverage report
         run: make build/cover.out
-      - name: Upload coverage report to Coveralls
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_BRANCH: ${{ github.head_ref }}
-        run: |
-          go install github.com/mattn/goveralls@latest
-          goveralls -service=github -coverprofile=build/cover.out
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: build/cover.out

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -27,7 +27,6 @@ golangciLint:
 githubWorkflow:
   ci:
     enabled: true
-    coveralls: true
   license:
     ignorePatterns:
       # vendored copies from upstream


### PR DESCRIPTION
This is required because go-makefile-maker rejects the previous config following <https://github.com/sapcc/go-makefile-maker/pull/351>.