### PR TITLE
[Hermes] Add dataplane config api get/put/delete

### DIFF
--- a/audit/v1/dataplaneconfig/requests.go
+++ b/audit/v1/dataplaneconfig/requests.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplaneconfig
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+// PutOpts specifies the fields for a Put request.
+type PutOpts struct {
+	Enabled      bool   `json:"enabled"`
+	TargetBucket string `json:"target_bucket,omitempty"`
+}
+
+// Get retrieves the dataplane configuration for the given project.
+// Returns the default (disabled) config when none has been set.
+func Get(ctx context.Context, c *gophercloud.ServiceClient, projectID string) (r GetResult) {
+	//nolint:bodyclose // already handled by gophercloud
+	resp, err := c.Get(ctx, resourceURL(c, projectID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Put creates or replaces the dataplane configuration for the given project.
+func Put(ctx context.Context, c *gophercloud.ServiceClient, projectID string, opts PutOpts) (r PutResult) {
+	//nolint:bodyclose // already handled by gophercloud
+	resp, err := c.Put(ctx, resourceURL(c, projectID), opts, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{http.StatusOK},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete removes the dataplane configuration for the given project.
+// Deleting a non-existent config is a no-op (returns 204).
+func Delete(ctx context.Context, c *gophercloud.ServiceClient, projectID string) (r DeleteResult) {
+	//nolint:bodyclose // already handled by gophercloud
+	resp, err := c.Delete(ctx, resourceURL(c, projectID), &gophercloud.RequestOpts{
+		OkCodes: []int{http.StatusNoContent},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/audit/v1/dataplaneconfig/results.go
+++ b/audit/v1/dataplaneconfig/results.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplaneconfig
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud/v2"
+)
+
+// DataplaneConfig holds the per-project dataplane routing configuration
+// returned by the Hermes API.
+type DataplaneConfig struct {
+	ProjectID    string    `json:"project_id"`
+	Enabled      bool      `json:"enabled"`
+	TargetBucket string    `json:"target_bucket,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	UpdatedBy    string    `json:"updated_by"`
+}
+
+// GetResult represents the result of a Get operation.
+type GetResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a GetResult as a DataplaneConfig.
+func (r GetResult) Extract() (*DataplaneConfig, error) {
+	var s DataplaneConfig
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto is used by Extract.
+func (r GetResult) ExtractInto(v any) error {
+	return r.ExtractIntoStructPtr(v, "")
+}
+
+// PutResult represents the result of a Put operation.
+type PutResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets a PutResult as a DataplaneConfig.
+func (r PutResult) Extract() (*DataplaneConfig, error) {
+	var s DataplaneConfig
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto is used by Extract.
+func (r PutResult) ExtractInto(v any) error {
+	return r.ExtractIntoStructPtr(v, "")
+}
+
+// DeleteResult represents the result of a Delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/audit/v1/dataplaneconfig/testing/fixtures.go
+++ b/audit/v1/dataplaneconfig/testing/fixtures.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+const GetResponse = `
+{
+  "project_id": "abcd1234efgh5678ijkl9012mnop3456",
+  "enabled": true,
+  "target_bucket": "audit-bucket",
+  "updated_at": "2026-07-08T10:00:00Z",
+  "updated_by": "u-42"
+}
+`
+
+const PutRequest = `
+{
+  "enabled": true,
+  "target_bucket": "audit-bucket"
+}
+`
+
+const PutResponse = GetResponse

--- a/audit/v1/dataplaneconfig/testing/requests_test.go
+++ b/audit/v1/dataplaneconfig/testing/requests_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	"github.com/gophercloud/gophercloud/v2/testhelper/client"
+
+	"github.com/sapcc/gophercloud-sapcc/v2/audit/v1/dataplaneconfig"
+)
+
+const testProjectID = "abcd1234efgh5678ijkl9012mnop3456"
+
+var expectedConfig = dataplaneconfig.DataplaneConfig{
+	ProjectID:    testProjectID,
+	Enabled:      true,
+	TargetBucket: "audit-bucket",
+	UpdatedAt:    time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC),
+	UpdatedBy:    "u-42",
+}
+
+func TestGet(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/projects/"+testProjectID+"/dataplane-config", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, GetResponse)
+	})
+
+	cfg, err := dataplaneconfig.Get(t.Context(), client.ServiceClient(fakeServer), testProjectID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedConfig, *cfg)
+}
+
+func TestPut(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/projects/"+testProjectID+"/dataplane-config", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPut)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, PutRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, PutResponse)
+	})
+
+	opts := dataplaneconfig.PutOpts{
+		Enabled:      true,
+		TargetBucket: "audit-bucket",
+	}
+
+	cfg, err := dataplaneconfig.Put(t.Context(), client.ServiceClient(fakeServer), testProjectID, opts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedConfig, *cfg)
+}
+
+func TestPutDisabledOmitsBucket(t *testing.T) {
+	// When Enabled=false and TargetBucket="", the request body must omit
+	// target_bucket entirely thanks to `omitempty`.
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/projects/"+testProjectID+"/dataplane-config", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPut)
+		th.TestJSONRequest(t, r, `{"enabled": false}`)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+  "project_id": "`+testProjectID+`",
+  "enabled": false,
+  "updated_at": "2026-07-08T10:00:00Z",
+  "updated_by": "u-42"
+}`)
+	})
+
+	_, err := dataplaneconfig.Put(t.Context(), client.ServiceClient(fakeServer), testProjectID, dataplaneconfig.PutOpts{}).Extract()
+	th.AssertNoErr(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	fakeServer := th.SetupHTTP()
+	defer fakeServer.Teardown()
+
+	fakeServer.Mux.HandleFunc("/projects/"+testProjectID+"/dataplane-config", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	res := dataplaneconfig.Delete(t.Context(), client.ServiceClient(fakeServer), testProjectID)
+	th.AssertNoErr(t, res.Err)
+}

--- a/audit/v1/dataplaneconfig/urls.go
+++ b/audit/v1/dataplaneconfig/urls.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplaneconfig
+
+import "github.com/gophercloud/gophercloud/v2"
+
+func resourceURL(c *gophercloud.ServiceClient, projectID string) string {
+	return c.ServiceURL("projects", projectID, "dataplane-config")
+}


### PR DESCRIPTION
## Motivation
The Hermes API now exposes per-project dataplane routing configuration
(GET/PUT/DELETE `/v1/projects/{project_id}/dataplane-config`), but the
`gophercloud-sapcc` client library has no Go binding for it. Consumers such
as `hermescli` cannot call these endpoints without hand-rolling HTTP
requests. This PR adds the missing client package so downstream tools can
integrate the new API through the standard gophercloud service-client
pattern.

## What Changed
- New package `audit/v1/dataplaneconfig` under the existing `audit-data`
  service client, alongside `events` and `attributes`.
- Exposes `Get`, `Put`, and `Delete` operations on the dataplane-config
  resource, plus a `DataplaneConfig` result type covering `project_id`,
  `enabled`, `target_bucket`, `updated_at`, and `updated_by`.
- Follows the same URL/results/requests file layout and `Extract` idioms
  used by the existing audit packages.

